### PR TITLE
Housing queue position now shows a more intuitive message.

### DIFF
--- a/conditional/blueprints/dashboard.py
+++ b/conditional/blueprints/dashboard.py
@@ -108,10 +108,9 @@ def display_dashboard():
         housing['points'] = ldap_get_housing_points(user_name)
         housing['room'] = ldap_get_room_number(user_name)
         if housing['room'] == "N/A":
-            housing['queue_pos'] = get_queue_position(user_name)
+            housing['queue_pos'] = "%s / %s" % (get_queue_position(user_name), get_queue_length())
         else:
-            housing['queue_pos'] = "On Floor"
-        housing['queue_len'] = get_queue_length()
+            housing['queue_pos'] = "N/A"
     else:
         housing = None
 

--- a/conditional/templates/dashboard.html
+++ b/conditional/templates/dashboard.html
@@ -240,7 +240,7 @@
                         </tr>
                         <tr>
                             <td class="title">Housing Queue Position</td>
-                            <td><span class="pull-right">{{housing['queue_pos']}} / {{housing['queue_len']}}</span></td>
+                            <td><span class="pull-right">{{housing['queue_pos']}}</span></td>
                         </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Fixes #29 

This is *an* approach. This way we can keep both the left and right columns of the dashboard info at 3 rows, so it looks more consistent. Thoughts?