### PR TITLE
Improve Evals Pages

### DIFF
--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -87,6 +87,7 @@ def display_intro_evals(internal=False):
                  ],
             'social_events': '',
             'freshman_project': "Pending",
+            'comments': "",
             'ldap_account': False,
             'status': "Pending"
         }
@@ -137,6 +138,7 @@ def display_intro_evals(internal=False):
                  ],
             'social_events': freshman_data.social_events,
             'freshman_project': freshman_data.freshman_project,
+            'comments': freshman_data.other_notes,
             'ldap_account': True,
             'status': freshman_data.freshman_eval_result
         }

--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -87,7 +87,7 @@ def display_intro_evals(internal=False):
                  ],
             'social_events': '',
             'freshman_project': "Pending",
-            'comments': 'Does not have account yet',
+            'ldap_account': False,
             'status': "Pending"
         }
         ie_members.append(freshman)
@@ -137,7 +137,7 @@ def display_intro_evals(internal=False):
                  ],
             'social_events': freshman_data.social_events,
             'freshman_project': freshman_data.freshman_project,
-            'comments': freshman_data.other_notes,
+            'ldap_account': True,
             'status': freshman_data.freshman_eval_result
         }
         ie_members.append(member)

--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -62,7 +62,7 @@ def display_intro_evals(internal=False):
             'name': fid.name,
             'uid': fid.id,
             'eval_date': fid.eval_date.strftime("%Y-%m-%d"),
-            'signatures_missed': 65535,
+            'signatures_missed': -1,
             'committee_meetings': get_fid_cm_count(fid.id),
             'committee_meetings_passed': get_fid_cm_count(fid.id) >= 10,
             'house_meetings_missed':

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -31,10 +31,10 @@ Introductory Evaluations
                     <div class="col-sm-5 col-md-6 col-lg-5 vcenter">
                         <div class="row">
                             <div class="text-center">
-                                {% if m['signatures_missed'] > 0 %}
+                                {% if m['signatures_missed'] == 65535 %}
+                                <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Packet in Progress</div>
+                                {% elif m['signatures_missed'] > 0 %}
                                 <div class="eval-info-label danger">Signatures Missed: {{m['signatures_missed']}}</div>
-                                {% elif m['signatures_missed'] == 65535 %}
-                                <div class="eval-info-label warning">Packet Not Yet Complete</div>
                                 {% else %}
                                 <div class="eval-info-label success">Signatures Missed: {{m['signatures_missed']}}</div>
                                 {% endif %}
@@ -49,7 +49,7 @@ Introductory Evaluations
                         </div>
                         <div class="text-center">
                             {% if m['freshman_project'] == "Pending" %}
-                            <div class="eval-info-label warning">Freshman Project: <span class="glyphicon glyphicon-hourglass white"></span></div>
+                            <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Project Results Pending</div>
                             {% elif m['freshman_project'] == "Passed" %}
                             <div class="eval-info-label success">Freshman Project: <span class="glyphicon glyphicon-ok-sign white"></span></div>
                             {% else %}

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -20,7 +20,12 @@ Introductory Evaluations
                     </div>
                     <div class="col-sm-5 col-md-4 col-lg-5">
                         <h4 class="eval-name">{{m['name']}}</h4>
-                        <h6 class="eval-uid">{{m['uid']}}</h6>
+                            {% if not m['ldap_account'] %}
+                                <span class="label label-default">Internal Account: {{m['uid']}}</span>
+                            {% else %}
+                                <h6 class="eval-uid">{{ m['uid'] }}</h6>
+                            {% endif %}
+
                     </div>
                     <!---->
                     <div class="col-sm-5 col-md-6 col-lg-5 vcenter">
@@ -63,11 +68,9 @@ Introductory Evaluations
                     </div>
                 </div>
             </div>
-            <div class="row">
-
+            {% if m['house_meetings_missed']|length != 0 or m['technical_seminars']|length != 0 %}
                 <button class="btn-expand-panel" role="button" data-toggle="collapse" href="#evalsCollapse-{{m['uid']}}" aria-expanded="false" aria-controls="evalsCollapse-{{m['uid']}}"><span class="glyphicon glyphicon glyphicon-menu-down"></span></button>
-
-            </div>
+            {% endif %}
             <div class="collapse" id="evalsCollapse-{{m['uid']}}">
                 {% if m['house_meetings_missed']|length > 0 %}
                 <!-- VV only display if missing house meetings VV -->
@@ -93,7 +96,7 @@ Introductory Evaluations
                 </table>
                 {% endif %}
                 <!-- ^^ HOUSE MEETINGS TABLE -->
-                {% if True or m['technical_seminars']|length > 0 %}
+                {% if m['technical_seminars']|length > 0 %}
 
                 <h4>Technical Seminars</h4>
                 <table class="table">
@@ -110,10 +113,6 @@ Introductory Evaluations
                 <h4>Social Events</h4>
                 <p>{{m['social_events']}}</p>
                 {% endif %}
-
-
-                <h4>Other Notes</h4>
-                <p>{{m['comments']}}</p>
             </div>
         </div>
 

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -68,7 +68,7 @@ Introductory Evaluations
                     </div>
                 </div>
             </div>
-            {% if m['house_meetings_missed']|length != 0 or m['technical_seminars']|length != 0 %}
+            {% if m['house_meetings_missed']|length != 0 or m['technical_seminars']|length != 0 or m['comments'] != "" %}
                 <button class="btn-expand-panel" role="button" data-toggle="collapse" href="#evalsCollapse-{{m['uid']}}" aria-expanded="false" aria-controls="evalsCollapse-{{m['uid']}}"><span class="glyphicon glyphicon glyphicon-menu-down"></span></button>
             {% endif %}
             <div class="collapse" id="evalsCollapse-{{m['uid']}}">
@@ -108,10 +108,17 @@ Introductory Evaluations
                         {% endfor %}
                     </tbody>
                 </table>
-                {% endif %} {% if m['social_events'] != "" %}
+                {% endif %}
+                {% if m['social_events'] != "" %}
 
                 <h4>Social Events</h4>
                 <p>{{m['social_events']}}</p>
+                {% endif %}
+
+                {% if m['comments'] != "" %}
+
+                <h4>Other Comments</h4>
+                <p>{{m['comments']}}</p>
                 {% endif %}
             </div>
         </div>

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -31,12 +31,12 @@ Introductory Evaluations
                     <div class="col-sm-5 col-md-6 col-lg-5 vcenter">
                         <div class="row">
                             <div class="text-center">
-                                {% if m['signatures_missed'] == 65535 %}
-                                <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Packet in Progress</div>
+                                {% if m['signatures_missed'] == 0 %}
+                                    <div class="eval-info-label success">Signatures Missed: {{m['signatures_missed']}}</div>
                                 {% elif m['signatures_missed'] > 0 %}
-                                <div class="eval-info-label danger">Signatures Missed: {{m['signatures_missed']}}</div>
+                                    <div class="eval-info-label danger">Signatures Missed: {{m['signatures_missed']}}</div>
                                 {% else %}
-                                <div class="eval-info-label success">Signatures Missed: {{m['signatures_missed']}}</div>
+                                    <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Packet in Progress</div>
                                 {% endif %}
                             </div>
                             <div class="text-center">

--- a/conditional/templates/spring_evals.html
+++ b/conditional/templates/spring_evals.html
@@ -55,13 +55,7 @@ Membership Evaluations
                         </div>
 
                 {% if m['house_meetings_missed']|length > 0 or m['major_projects_len'] > 0 %}
-                <div class="row">
-                    <div class="col-xs-12 col-sm-12 col-md-12">
-
                         <button class="btn-expand-panel" role="button" data-toggle="collapse" href="#evalsCollapse{{m['uid']}}" aria-expanded="false" aria-controls="evalsCollapse{{m['uid']}}"><span class="glyphicon glyphicon glyphicon-menu-down"></span></button>
-
-                    </div>
-                </div>
                 {% endif %}
                 <div class="collapse" id="evalsCollapse{{m['uid']}}">
                     {% if m['house_meetings_missed']|length > 0 %}

--- a/frontend/stylesheets/pages/_evals.scss
+++ b/frontend/stylesheets/pages/_evals.scss
@@ -18,7 +18,7 @@
 }
 
 .eval-panel {
-  padding: 25px 20px 10px;
+  padding: 25px 20px;
 }
 
 .col-sm-2 {
@@ -49,6 +49,7 @@
     border: 0;
     background: transparent;
     width: 100%;
+    height: 0;
     text-align: center;
   }
 }


### PR DESCRIPTION
- Fix dropdown display login on intro evals page.
- Actually display pending results instead of 65535
- Match freshmen project pending status to pending packet.
- Fix adding issues when dropdown is hidden.

<img width="1307" alt="screen shot 2016-09-06 at 16 52 17" src="https://cloud.githubusercontent.com/assets/8651166/18290862/1b62a7bc-7453-11e6-8442-402537c1917a.png">
