### PR TITLE
Add virtualenv dir from readme to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# Ipython Notebook
 .ipynb_checkpoints
 
 # JetBrains IDEs
@@ -78,3 +78,6 @@ target/
 
 # Built frontend files
 /conditional/static/*
+
+# virtualenv
+/.conditionalenv


### PR DESCRIPTION
Minor detail, but contributors following the instructions on the readme will see `.conditionalenv` in their git status, which prevents the use of `git commit .` and could easily be committed by accident.

Since this is the default virtualenv folder used in the readme, I think it's worth adding to the gitignore.