### PR TITLE
Add standard icon spacing for all icons

### DIFF
--- a/conditional/templates/base.html
+++ b/conditional/templates/base.html
@@ -24,7 +24,7 @@
             {% endblock %}
         {% else %}
         <div class="container main">
-            <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-remove-sign"></span> Site Lockdown: Evaluations in progress. Please check back later.</div>
+            <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-remove-sign icon-space-r"></span> Site Lockdown: Evaluations in progress. Please check back later.</div>
         </div>
         {% endif %}
 

--- a/conditional/templates/dashboard.html
+++ b/conditional/templates/dashboard.html
@@ -34,11 +34,11 @@ Dashboard
                 <div class="panel-heading">
                     <h3 class="panel-title">Freshman Evaluations
                         {% if freshman['status'] == "Passed" %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-ok-sign green"></span> Passed</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> Passed</span>
                         {% elif freshman['status'] == "Pending" %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-hourglass yellow"></span> Pending</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> Pending</span>
                         {% else %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-remove-sign red"></span> Failed</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> Failed</span>
                         {% endif %}
                     </h3>
                 </div>
@@ -53,8 +53,8 @@ Dashboard
                             <td class="title">Signatures Missed</td>
                             <td><span class="pull-right">
                                 {% if freshman['sig_missed'] == 0 %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> None {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> {{freshman['sig_missed']}} {% endif %}
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> None {% else %}
+                                <span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> {{freshman['sig_missed']}} {% endif %}
                                 </span>
                             </td>
                         </tr>
@@ -62,8 +62,8 @@ Dashboard
                             <td class="title">Directorship Meetings</td>
                             <td><span class="pull-right">
                                 {% if freshman['committee_meetings'] >= 10 %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> {% endif %} {{freshman['committee_meetings']}} / 10
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> {% else %}
+                                <span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> {% endif %} {{freshman['committee_meetings']}} / 10
                                 </span>
                             </td>
                         </tr>
@@ -71,8 +71,8 @@ Dashboard
                             <td class="title">House Meetings Missed</td>
                             <td><span class="pull-right">
                                 {% if freshman['hm_missed'] == 0 %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> None {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> {{ freshman['hm_missed'] }} {% endif %}
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> None {% else %}
+                                <span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> {{ freshman['hm_missed'] }} {% endif %}
                                 </span>
                             </td>
                         </tr>
@@ -80,11 +80,11 @@ Dashboard
                             <td class="title">Freshman Project</td>
                             <td>
                                 {% if freshman['fresh_proj'] == "Passed" %}
-                                <span class="pull-right"><span class="glyphicon glyphicon-ok-sign green"></span> Passed</span>
+                                <span class="pull-right"><span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> Passed</span>
                                 {% elif freshman['fresh_proj'] == "Pending" %}
-                                <span class="pull-right"><span class="glyphicon glyphicon-hourglass yellow"></span> Pending</span>
+                                <span class="pull-right"><span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> Pending</span>
                                 {% else %}
-                                <span class="pull-right"><span class="glyphicon glyphicon-remove-sign red"></span> Failed</span>
+                                <span class="pull-right"><span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> Failed</span>
                                 {% endif %}
                             </td>
                         </tr>
@@ -113,11 +113,11 @@ Dashboard
                 <div class="panel-heading">
                     <h3 class="panel-title">Membership Evaluations
                         {% if spring['status'] == "Passed" %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-ok-sign green"></span> Passed</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-ok-sign icon-space-r green"></span>Passed</span>
                         {% elif spring['status'] == "Failed" %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-remove-sign red"></span> Failed</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-remove-sign icon-space-r red"></span>Failed</span>
                         {% else %}
-                        <span class="pull-right"><span class="glyphicon glyphicon-hourglass yellow"></span> Pending</span>
+                        <span class="pull-right"><span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span>Pending</span>
                         {% endif %}
                     </h3>
                 </div>
@@ -128,16 +128,16 @@ Dashboard
                             <td class="title">Directorship Meetings</td>
                             <td><span class="pull-right">
                                 {% if spring['committee_meetings'] >= 25 %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> {% endif %} {{ spring['committee_meetings'] }} / 25</span>
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> {% else %}
+                                <span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> {% endif %} {{ spring['committee_meetings'] }} / 25</span>
                             </td>
                         </tr>
                         <tr>
                             <td class="title">House Meetings Missed</td>
                             <td><span class="pull-right">
                                 {% if spring['hm_missed'] == 0 %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> None {% else %}
-                                <span><span class="glyphicon glyphicon-remove-sign red"></span> {{spring['hm_missed']}}</span>
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> None {% else %}
+                                <span><span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> {{spring['hm_missed']}}</span>
                                 {% endif %}
                                 </span>
                             </td>
@@ -147,9 +147,9 @@ Dashboard
                             <td>
                                 <span class="pull-right">
                                 {% if spring['mp_status'] == "Passed" %}
-                                <span class="glyphicon glyphicon-ok-sign green"></span> Passed {% elif spring['mp_status'] == "Pending" %}
-                                <span class="glyphicon glyphicon-hourglass yellow"></span> Pending {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> None {% endif %}
+                                <span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> Passed {% elif spring['mp_status'] == "Pending" %}
+                                <span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> Pending {% else %}
+                                <span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> None {% endif %}
                                 </span>
                             </td>
                         </tr>
@@ -180,9 +180,9 @@ Dashboard
                                 <td>{{c['description']}}</td>
                                 <td>
                                     {% if c['status'] == "Passed" %}
-                                    <span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-ok-sign green"></span> {% elif c['status'] == "Pending" %}
-                                    <span class="glyphicon glyphicon-hourglass yellow"></span> <span class="mobile-hide">Pending</span> {% else %}
-                                    <span class="glyphicon glyphicon-minus-sign red"></span> <span class="mobile-hide">Failed</span> {% endif %}
+                                    <span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-ok-sign icon-space-r green"></span> {% elif c['status'] == "Pending" %}
+                                    <span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> <span class="mobile-hide">Pending</span> {% else %}
+                                    <span class="glyphicon glyphicon-minus-sign icon-space-r red"></span> <span class="mobile-hide">Failed</span> {% endif %}
                                 </td>
                             </tr>
                             {% endfor %}
@@ -195,7 +195,7 @@ Dashboard
             {% endif %}
 
             {% if major_projects_count == 0 %}
-            <div class="alert alert-warning" role="alert"> <span class="glyphicon glyphicon-exclamation-sign white" style="padding-right:5px"> </span> You have no major projects.</div>
+            <div class="alert alert-warning" role="alert"> <span class="glyphicon glyphicon-exclamation-sign icon-space-r white"> </span> You have no major projects.</div>
             {% else %}
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -205,13 +205,13 @@ Dashboard
                     {% for p in major_projects %}
                     <tr>
                         {% if p['status'] == "Passed" %}
-                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-ok-sign green"></span> {{p['name']}}
+                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-ok-sign icon-space-r green"></span> {{p['name']}}
                     </span>
                         {% elif p['status'] == "Pending" %}
-                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-hourglass yellow"></span> {{p['name']}}
+                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> {{p['name']}}
                     </span>
                         {% else %}
-                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-minus-sign red"></span> {{p['name']}}
+                        <span class="title"><span style="padding-left:15px; padding-top:15px;" class="glyphicon glyphicon-minus-sign icon-space-r red"></span> {{p['name']}}
                     </span>
                         {% endif %}
                         <div class="panel-body" style="word-wrap:break-word">{{p['description']}}</div>
@@ -229,7 +229,7 @@ Dashboard
                     <h3 class="panel-title">Housing Status</h3>
                 </div>
                 <div class="panel-body table-fill">
-                    
+
                     <table class="table table-striped table-responsive no-bottom-margin">
                         <tbody>
                         <tr>
@@ -252,7 +252,7 @@ Dashboard
 
             {% if hm_attendance_len == 0 %}
             <div class="alert alert-success">
-                <span class="glyphicon glyphicon-ok-sign white" style="padding-right:5px"> </span> You haven't missed any house meetings.
+                <span class="glyphicon glyphicon-ok-sign icon-space-r white"> </span> You haven't missed any house meetings.
             </div>
             {% else %}
             <div class="panel panel-default">
@@ -279,7 +279,7 @@ Dashboard
             {% endif %}
 
             {% if cm_attendance_len == 0 %}
-            <div class="alert alert-warning"><span class="glyphicon glyphicon-exclamation-sign white" style="padding-right:5px"></span> You have not attended any directorship meetings.</div>
+            <div class="alert alert-warning"><span class="glyphicon glyphicon-exclamation-sign icon-space-r white"></span> You have not attended any directorship meetings.</div>
             {% else %}
             <div class="panel panel-default">
                 <div class="panel-heading">

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -36,7 +36,7 @@ Introductory Evaluations
                                 {% elif m['signatures_missed'] > 0 %}
                                     <div class="eval-info-label danger">Signatures Missed: {{m['signatures_missed']}}</div>
                                 {% else %}
-                                    <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Packet in Progress</div>
+                                    <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass icon-space-r white"></span> Packet in Progress</div>
                                 {% endif %}
                             </div>
                             <div class="text-center">
@@ -49,11 +49,11 @@ Introductory Evaluations
                         </div>
                         <div class="text-center">
                             {% if m['freshman_project'] == "Pending" %}
-                            <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass white"></span> Project Results Pending</div>
+                            <div class="eval-info-label warning"><span class="glyphicon glyphicon-hourglass icon-space-r white"></span> Project Results Pending</div>
                             {% elif m['freshman_project'] == "Passed" %}
-                            <div class="eval-info-label success">Freshman Project: <span class="glyphicon glyphicon-ok-sign white"></span></div>
+                            <div class="eval-info-label success">Freshman Project: <span class="glyphicon glyphicon-ok-sign icon-space-l white"></span></div>
                             {% else %}
-                            <div class="eval-info-label danger">Freshman Project: <span class="glyphicon glyphicon-remove-sign white"></span></div>
+                            <div class="eval-info-label danger">Freshman Project: <span class="glyphicon glyphicon-remove-sign icon-space-l white"></span></div>
                             {% endif %}
 
                         </div>
@@ -128,7 +128,7 @@ Introductory Evaluations
 </div>
 {% endfor %}
 {% else %}
-    <div class="alert alert-info" role="alert"><span class="glyphicon glyphicon-info-sign white" style="padding-right:5px"></span> There are currently no active intro members.</div>
+    <div class="alert alert-info" role="alert"><span class="glyphicon glyphicon-info-sign icon-space-r white"></span> There are currently no active intro members.</div>
 {% endif %}
 </div>
 {% endblock %}

--- a/conditional/templates/intro_evals_form.html
+++ b/conditional/templates/intro_evals_form.html
@@ -27,7 +27,7 @@ Introductory Evaluations Form
         <input class= "btn btn-raised btn-primary" style="width:100%;" type="submit" value="Submit Introductory Evaluation">
     </form>
     {% else %}
-    <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-remove-sign"></span> The submission period for this form has ended.</div>
+    <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-remove-sign icon-space-r"></span> The submission period for this form has ended.</div>
     {% endif %}
 </div>
 {% endblock %}

--- a/conditional/templates/member_management.html
+++ b/conditional/templates/member_management.html
@@ -86,7 +86,7 @@ Administration
 
     {% if is_eval_director %}
     {% if freshmen|length == 0 %}
-    <div class="alert alert-info" role="alert"><span class="glyphicon glyphicon-info-sign white" style="padding-right:5px"> </span> There are currently no freshmen accounts.</div>
+    <div class="alert alert-info" role="alert"><span class="glyphicon glyphicon-info-sign icon-space-r white"> </span> There are currently no freshmen accounts.</div>
     {% else %}
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -209,7 +209,7 @@ Administration
                     </div>
 
                     <p class="lead">Missed House Meetings</p>
-                    <div class="alert alert-info no-missed-hm-alert" role="alert"><span class="glyphicon glyphicon-info-sign white" style="padding-right:5px"> </span> This member has not missed any house meetings.</div>
+                    <div class="alert alert-info no-missed-hm-alert" role="alert"><span class="glyphicon glyphicon-info-sign icon-space-r white"> </span> This member has not missed any house meetings.</div>
                     <div class="row hm-wrapper missed-hm-tpl">
                         <div class="col-xs-4">
                             <h6 class="hm-date">07/31/2016</h6>
@@ -224,7 +224,7 @@ Administration
                         </div>
                         <div class="col-xs-4">
                             <button type="button" class="btn btn-outline-secondary btn-sm hm-present-btn">
-                            <span class="glyphicon glyphicon-ok green" style="padding-right:5px"></span>Mark Present
+                            <span class="glyphicon glyphicon-ok icon-space-r green"></span>Mark Present
                             </button>
                         </div>
                         <div class="col-xs-12">
@@ -278,7 +278,7 @@ Administration
                     </div>
 
                     <p class="lead">Missed House Meetings</p>
-                    <div class="alert alert-info no-missed-hm-alert" role="alert"><span class="glyphicon glyphicon-info-sign white" style="padding-right:5px"></span> This member has not missed any house meetings.</div>
+                    <div class="alert alert-info no-missed-hm-alert" role="alert"><span class="glyphicon glyphicon-info-sign icon-space-r white"></span> This member has not missed any house meetings.</div>
                     <div class="row hm-wrapper missed-hm-tpl">
                         <div class="col-xs-4">
                             <h6 class="hm-date">07/31/2016</h6>
@@ -293,7 +293,7 @@ Administration
                         </div>
                         <div class="col-xs-4">
                             <button type="button" class="btn btn-outline-secondary btn-sm hm-present-btn">
-                                <span class="glyphicon glyphicon-ok green" style="padding-right:5px"></span>Mark Present
+                                <span class="glyphicon glyphicon-ok icon-space-r green"></span> Mark Present
                             </button>
                         </div>
                         <div class="col-xs-12">

--- a/conditional/templates/nav.html
+++ b/conditional/templates/nav.html
@@ -14,45 +14,45 @@
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-stats"></span> Evals <span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-stats icon-space-r"></span> Evals <span class="caret icon-space-l"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/intro_evals"><span class="glyphicon glyphicon-star"></span> Introductory Evaluations</a></li>
-                        <li><a href="/spring_evals"><span class="glyphicon glyphicon-tree-deciduous"></span> Membership Evaluations</a></li>
-                        <li><a href="/conditionals"><span class="glyphicon glyphicon-exclamation-sign"></span> Current Conditionals</a></li>
+                        <li><a href="/intro_evals"><span class="glyphicon glyphicon-star icon-space-r"></span> Introductory Evaluations</a></li>
+                        <li><a href="/spring_evals"><span class="glyphicon glyphicon-tree-deciduous icon-space-r"></span> Membership Evaluations</a></li>
+                        <li><a href="/conditionals"><span class="glyphicon glyphicon-exclamation-sign icon-space-r"></span> Current Conditionals</a></li>
                     </ul>
                 </li>
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-list-alt"></span> Forms <span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-list-alt icon-space-r"></span> Forms <span class="caret icon-space-l"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/major_project"><span class="glyphicon glyphicon-star"></span> Major Project</a></li>
+                        <li><a href="/major_project"><span class="glyphicon glyphicon-star icon-space-r"></span> Major Project</a></li>
                         {% if is_intromember %}
-                        <li><a href="/intro_evals_form"><span class="glyphicon glyphicon-blackboard"></span> Introductory Evaluations</a></li>
+                        <li><a href="/intro_evals_form"><span class="glyphicon glyphicon-blackboard icon-space-r"></span> Introductory Evaluations</a></li>
                         {% endif %}
                     </ul>
                 </li>
 
-                <li><a href="/housing"><span class="glyphicon glyphicon-home"></span> Housing</a></li>
+                <li><a href="/housing"><span class="glyphicon glyphicon-home icon-space-r"></span> Housing</a></li>
                 {% if is_eboard %}
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-ok"></span> Attendance <span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-ok icon-space-r"></span> Attendance <span class="caret icon-space-l"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/attendance_cm"><span class="glyphicon glyphicon-briefcase"></span> Directorship Meeting </a></li>
-                        <li><a href="/attendance_ts"><span class="glyphicon glyphicon-blackboard"></span> Technical Seminar</a></li>
+                        <li><a href="/attendance_cm"><span class="glyphicon glyphicon-briefcase icon-space-r"></span> Directorship Meeting </a></li>
+                        <li><a href="/attendance_ts"><span class="glyphicon glyphicon-blackboard icon-space-r"></span> Technical Seminar</a></li>
                         {% if is_eval_director %}
-                        <li><a href="/attendance_hm"><span class="glyphicon glyphicon-home"></span> House Meeting</a></li>
+                        <li><a href="/attendance_hm"><span class="glyphicon glyphicon-home icon-space-r"></span> House Meeting</a></li>
                         {% endif %}
                     </ul>
                 </li>
                 {% endif %}
                 {% if is_eval_director or is_financial_director %}
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-wrench"></span> Admin<span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-wrench icon-space-r"></span> Admin<span class="caret icon-space-l"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/manage"><span class="glyphicon glyphicon-user"></span> Member Management</a></li>
+                        <li><a href="/manage"><span class="glyphicon glyphicon-user icon-space-r"></span> Member Management</a></li>
                         {% if is_eval_director %}
 
-                        <li><a href="/slideshow/intro"><span class="glyphicon glyphicon-eye-open"></span> Introductory Evaluations Presentation</a></li>
-                        <li><a href="/slideshow/spring"><span class="glyphicon glyphicon-eye-open"></span> Membership Evaluations Presentation</a></li>
+                        <li><a href="/slideshow/intro"><span class="glyphicon glyphicon-eye-open icon-space-r"></span> Introductory Evaluations Presentation</a></li>
+                        <li><a href="/slideshow/spring"><span class="glyphicon glyphicon-eye-open icon-space-r"></span> Membership Evaluations Presentation</a></li>
 
                         {% endif %}
                     </ul>
@@ -67,15 +67,15 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
                         <img src="https://profiles.csh.rit.edu/image/{{username}}">
                         {{username}}
-                        <span class="caret"></span>
+                        <span class="caret icon-space-l"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a href="/dashboard"><span class="glyphicon glyphicon-dashboard"></span> Dashboard</a></li>
-                        <li><a href="https://profiles.csh.rit.edu/user/{{username}}"><span class="glyphicon glyphicon-user"></span> Profiles</a></li>
+                        <li><a href="/dashboard"><span class="glyphicon glyphicon-dashboard icon-space-r"></span> Dashboard</a></li>
+                        <li><a href="https://profiles.csh.rit.edu/user/{{username}}"><span class="glyphicon glyphicon-user icon-space-r"></span> Profiles</a></li>
                         <li role="separator" class="divider"></li>
-                        <li><a href="https://members.csh.rit.edu/"><span class="glyphicon glyphicon-globe"></span> Members Portal</a></li>
-                        <li><a href="https://github.com/ComputerScienceHouse/conditional/issues"><span class="glyphicon glyphicon-exclamation-sign"></span> Report an Issue</a></li>
-                        <li><a href="https://webauth.csh.rit.edu/logout"><span class="glyphicon glyphicon-log-out"></span> Webauth Logout</a></li>
+                        <li><a href="https://members.csh.rit.edu/"><span class="glyphicon glyphicon-globe icon-space-r"></span> Members Portal</a></li>
+                        <li><a href="https://github.com/ComputerScienceHouse/conditional/issues"><span class="glyphicon glyphicon-exclamation-sign icon-space-r"></span> Report an Issue</a></li>
+                        <li><a href="https://webauth.csh.rit.edu/logout"><span class="glyphicon glyphicon-log-out icon-space-r"></span> Webauth Logout</a></li>
                     </ul>
                 </li>
             </ul>

--- a/conditional/templates/spring_evals.html
+++ b/conditional/templates/spring_evals.html
@@ -34,11 +34,11 @@ Membership Evaluations
                                     </div>
                                     <div class="text-center">
                                         {% if m['major_project_passed'] %}
-                                        <div class="eval-info-label success">Major Project: <span class="glyphicon glyphicon-ok-sign white"></span></div>
+                                        <div class="eval-info-label success">Major Project: <span class="glyphicon glyphicon-ok-sign icon-space-l white"></span></div>
                                         {% elif m['major_project_passed'] %}
-                                        <div class="eval-info-label warning">Major Project: <span class="glyphicon glyphicon-hourglass white"></span></div>
+                                        <div class="eval-info-label warning">Major Project: <span class="glyphicon glyphicon-hourglass icon-space-l white"></span></div>
                                         {% else %}
-                                        <div class="eval-info-label danger">Major Project: <span class="glyphicon glyphicon-remove-sign white"></span></div>
+                                        <div class="eval-info-label danger">Major Project: <span class="glyphicon glyphicon-remove-sign icon-space-l white"></span></div>
                                         {% endif %}
 
                                     </div>
@@ -116,11 +116,11 @@ Membership Evaluations
                             <tr>
                                 <td>{{p['name']}}</td>
                                 {% if p['status'] == "Passed" %}
-                                <td><span class="glyphicon glyphicon-ok-sign green"></span> Passed</td>
+                                <td><span class="glyphicon glyphicon-ok-sign icon-space-r green"></span> Passed</td>
                                 {% elif p['status'] == "Pending" %}
-                                <td><span class="glyphicon glyphicon-hourglass yellow"></span> Pending</td>
+                                <td><span class="glyphicon glyphicon-hourglass icon-space-r yellow"></span> Pending</td>
                                 {% else %}
-                                <td><span class="glyphicon glyphicon-remove-sign red"></span> Failed</td>
+                                <td><span class="glyphicon glyphicon-remove-sign icon-space-r red"></span> Failed</td>
                                 {% endif %}
                                 <td>{{p['description']}}</td>
                             </tr>

--- a/frontend/stylesheets/app.scss
+++ b/frontend/stylesheets/app.scss
@@ -17,6 +17,7 @@
 @import 'components/select';
 @import 'components/dropzone';
 @import 'components/sweet-alert/sweet-alert';
+@import 'components/icons';
 
 // Pages
 @import 'pages/dashboard';

--- a/frontend/stylesheets/components/_icons.scss
+++ b/frontend/stylesheets/components/_icons.scss
@@ -1,0 +1,7 @@
+.icon-space-r {
+  margin-right: 0.4em;
+}
+
+.icon-space-l {
+  margin-left: 0.4em;
+}


### PR DESCRIPTION
* Sets a standard distance for all icon spacing
* Uses em so that it scales proportionally to font size

I use this in all my projects as I think icons look a ton better when they're not up right against the text. Adding a space only does so much, and spaces can't stack to increase the distance.

I couldn't get a local environment working so I couldn't fully test this locally, but applying my changes in the web inspector looks like this:

Before:
![screenshot 2016-09-07 21 52 25](https://cloud.githubusercontent.com/assets/1441807/18337506/388a7c68-7546-11e6-898f-e94f70819ced.png)

After:
![screenshot 2016-09-07 21 59 05](https://cloud.githubusercontent.com/assets/1441807/18337515/500d50a4-7546-11e6-8ac2-c596c02523a7.png)
