### PR TITLE
Stop Duplication of OnFloorStatusAssigned Objects

### DIFF
--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -39,6 +39,7 @@ from conditional.util.ldap import ldap_is_active
 from conditional.util.ldap import ldap_is_onfloor
 from conditional.util.ldap import __ldap_add_member_to_group__ as ldap_add_member_to_group
 from conditional.util.ldap import __ldap_remove_member_from_group__ as ldap_remove_member_from_group
+from conditional.util.ldap import __ldap_is_member_of_group__ as ldap_is_member_of_group
 
 from conditional.util.flask import render_template
 from conditional.models.models import attendance_enum
@@ -251,8 +252,10 @@ def edit_uid(uid, user_name, post_data):
 
         ldap_set_roomnumber(uid, room_number)
         if onfloor_status:
-            db.session.add(OnFloorStatusAssigned(uid, datetime.now()))
-            ldap_add_member_to_group(uid, "onfloor")
+            # If a OnFloorStatusAssigned object exists, don't make another
+            if not ldap_is_member_of_group(uid, "onfloor"):
+                db.session.add(OnFloorStatusAssigned(uid, datetime.now()))
+                ldap_add_member_to_group(uid, "onfloor")
         else:
             for ofs in OnFloorStatusAssigned.query.filter(OnFloorStatusAssigned.uid == uid):
                 db.session.delete(ofs)

--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -262,7 +262,8 @@ def edit_uid(uid, user_name, post_data):
             db.session.flush()
             db.session.commit()
 
-            ldap_remove_member_from_group(uid, "onfloor")
+            if ldap_is_member_of_group(uid, "onfloor"):
+                ldap_remove_member_from_group(uid, "onfloor")
         ldap_set_housingpoints(uid, housing_points)
 
     # Only update if there's a diff

--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -37,9 +37,9 @@ from conditional.util.ldap import ldap_get_active_members
 from conditional.util.ldap import ldap_get_name
 from conditional.util.ldap import ldap_is_active
 from conditional.util.ldap import ldap_is_onfloor
-from conditional.util.ldap import ldap_add_member_to_group
-from conditional.util.ldap import ldap_remove_member_from_group
-from conditional.util.ldap import ldap_is_member_of_group
+from conditional.util.ldap import _ldap_add_member_to_group as ldap_add_member_to_group
+from conditional.util.ldap import _ldap_remove_member_from_group as ldap_remove_member_from_group
+from conditional.util.ldap import _ldap_is_member_of_group as ldap_is_member_of_group
 
 from conditional.util.flask import render_template
 from conditional.models.models import attendance_enum

--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -37,9 +37,9 @@ from conditional.util.ldap import ldap_get_active_members
 from conditional.util.ldap import ldap_get_name
 from conditional.util.ldap import ldap_is_active
 from conditional.util.ldap import ldap_is_onfloor
-from conditional.util.ldap import __ldap_add_member_to_group__ as ldap_add_member_to_group
-from conditional.util.ldap import __ldap_remove_member_from_group__ as ldap_remove_member_from_group
-from conditional.util.ldap import __ldap_is_member_of_group__ as ldap_is_member_of_group
+from conditional.util.ldap import ldap_add_member_to_group
+from conditional.util.ldap import ldap_remove_member_from_group
+from conditional.util.ldap import ldap_is_member_of_group
 
 from conditional.util.flask import render_template
 from conditional.models.models import attendance_enum


### PR DESCRIPTION
Currently there is no check to prevent making another OnFloorStatusAssigned
object if a member is edited in the Member Management page.

I'll ping in this thread once I've sufficiently tested this.