### PR TITLE
Fixed conditional submission and added missed packet signatures

### DIFF
--- a/conditional/templates/intro_eval_slideshow.html
+++ b/conditional/templates/intro_eval_slideshow.html
@@ -13,32 +13,40 @@ Introductory Evaluations Slideshow
     <section id="slide-{{m['uid']}}">
       <section>
         <h1>{{m['name']}}</h1>
-        <div class="row">
-          <div class="col-xs-12 col-md-4">
-            {% set committee_meetings_passed = m['committee_meetings'] >= 10 %}
-            <div class="item{% if committee_meetings_passed %} passed{% endif %}" >
-              <span class="icon glyphicon glyphicon-{% if committee_meetings_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
-              <h3>{{m['committee_meetings']}}</h3>
-              <p>Meetings</p>
+          <div class="row">
+            <div class="col-xs-12 col-md-3">
+              {% set packet_passed = m['signatures_missed'] == 0 %}
+              <div class="item{% if packet_passed %} passed{% endif %}" >
+                <span class="icon glyphicon glyphicon-{% if packet_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
+                <h3>{{m['signatures_missed']}}</h3>
+                <p>Signatures Missed</p>
+              </div>
+            </div>
+            <div class="col-xs-12 col-md-3">
+              {% set committee_meetings_passed = m['committee_meetings'] >= 10 %}
+              <div class="item{% if committee_meetings_passed %} passed{% endif %}" >
+                <span class="icon glyphicon glyphicon-{% if committee_meetings_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
+                <h3>{{m['committee_meetings']}}</h3>
+                <p>Meetings</p>
+              </div>
+            </div>
+            <div class="col-xs-12 col-md-3">
+              {% set house_meetings_passed = m['house_meetings_missed']|length == 0 %}
+              <div class="item{% if house_meetings_passed %} passed{% endif %}">
+                <span class="icon glyphicon glyphicon-{% if house_meetings_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
+                <h3>{{m['house_meetings_missed']|length}}</h3>
+                <p>Absences</p>
+              </div>
+            </div>
+            <div class="col-xs-12 col-md-3">
+              {% set technical_seminars_passed = m['technical_seminars']|length >= 2 %}
+              <div class="item{% if technical_seminars_passed %} passed{% endif %}">
+                <span class="icon glyphicon glyphicon-{% if technical_seminars_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
+                <h3>{{m['technical_seminars']|length}}</h3>
+                <p>Seminars</p>
+              </div>
             </div>
           </div>
-          <div class="col-xs-12 col-md-4">
-            {% set house_meetings_passed = m['house_meetings_missed']|length == 0 %}
-            <div class="item{% if house_meetings_passed %} passed{% endif %}">
-              <span class="icon glyphicon glyphicon-{% if house_meetings_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
-              <h3>{{m['house_meetings_missed']|length}}</h3>
-              <p>Absences</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-md-4">
-            {% set technical_seminars_passed = m['technical_seminars']|length >= 2 %}
-            <div class="item{% if technical_seminars_passed %} passed{% endif %}">
-              <span class="icon glyphicon glyphicon-{% if technical_seminars_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
-              <h3>{{m['technical_seminars']|length}}</h3>
-              <p>Seminars</p>
-            </div>
-          </div>
-        </div>
         <h4><span class="icon glyphicon glyphicon-{% if m['freshman_project'] == 'Passed' %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span> Freshman Project</h4>
         
         <div class="actions" data-uid="{{m['uid']}}" data-cn="{{m['name']}}">

--- a/frontend/javascript/modules/conditionalForm.js
+++ b/frontend/javascript/modules/conditionalForm.js
@@ -15,8 +15,9 @@ export default class ConditionalForm {
 
   _submitForm(e) {
     e.preventDefault();
+    let uid = this.form.uid.value;
     let payload = {
-      uid: this.form.uid.value,
+      uid: uid,
       description: this.form.querySelector('input[name=description]').value,
       dueDate: this.form.querySelector('input[name=due_date]').value
     };
@@ -26,6 +27,12 @@ export default class ConditionalForm {
     }, () => {
       $(this.form.closest('.modal')).modal('hide');
       if (location.pathname.split('/')[1] === "slideshow") {
+        $('#createConditional').on('hidden.bs.modal', function() {
+          var condBtn = $('div[data-uid="' + uid + '"] button')
+          .first();
+          $(condBtn).text("Conditionaled").off("click").addClass("disabled");
+          $(condBtn).next().hide();
+        });
         reveal.right();
       } else {
         location.reload();

--- a/frontend/javascript/modules/presentation.js
+++ b/frontend/javascript/modules/presentation.js
@@ -42,10 +42,6 @@ export default class Presentation {
           $('#createConditional').modal();
           $('#createConditional input[type="text"]').val('');
           $('#createConditional input[name="uid"]').val(uid);
-          $('#createConditional').on('hidden.bs.modal', function() {
-            $(e.target).text("Conditionaled").off("click").addClass("disabled");
-            $(e.target).next().hide();
-          });
         });
       $(e.target).click(e => {
         e.preventDefault();

--- a/frontend/stylesheets/components/_reveal.scss
+++ b/frontend/stylesheets/components/_reveal.scss
@@ -105,10 +105,11 @@ $yellow: #f1c40f;
   }
   & .item {
     position: relative;
+    margin: 0 auto;
     border: 6px solid $red;
     border-radius: 20px;
     padding: 60px 0 0;
-    width: 95%;
+    width: 92%;
     height: 100%;
     color: #555;
     &.passed {

--- a/frontend/stylesheets/components/reveal/_white.scss
+++ b/frontend/stylesheets/components/reveal/_white.scss
@@ -72,6 +72,7 @@ body {
 }
 
 .reveal .item p {
+  font-size: .6em;
   font-weight: normal;
 }
 


### PR DESCRIPTION
The presentation currently advances (goes to next slide, marks and disables button as "Conditionaled") on just closing the conditional modal, regardless of if it successfully went through, or if there was even any data entered or submitted. I moved the functionality to advance through the slides to the success callback for the modal, so that it only executes on a successful submission of a conditional. 