### PR TITLE
Changed intro member sorting order

### DIFF
--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -151,10 +151,10 @@ def display_intro_evals(internal=False):
         }
         ie_members.append(member)
 
-    ie_members.sort(key=lambda x: x['freshman_project'] == "Passed")
     ie_members.sort(key=lambda x: len(x['house_meetings_missed']))
     ie_members.sort(key=lambda x: x['committee_meetings'], reverse=True)
     ie_members.sort(key=lambda x: x['signatures_missed'])
+    ie_members.sort(key=lambda x: x['freshman_project'] == "Passed")
 
     if internal:
         return ie_members


### PR DESCRIPTION
Moved intro members that failed freshman project to the bottom of
the conditional sort.

Members that failed the freshman project were still intermingled with
those who were not as opposed to on the bottom.