### PR TITLE
Fix #111 by invalidating the appropriate cache when ldap variables ar…

### DIFF
--- a/conditional/blueprints/cache_management.py
+++ b/conditional/blueprints/cache_management.py
@@ -68,3 +68,7 @@ def clear_members_cache():
 
 def clear_committee_cache():
     _ldap_is_member_of_directorship.clear_cache()
+
+
+def clear_current_students_cache():
+    ldap.get_current_students.cache_clear()

--- a/conditional/blueprints/cache_management.py
+++ b/conditional/blueprints/cache_management.py
@@ -68,7 +68,3 @@ def clear_members_cache():
 
 def clear_committee_cache():
     _ldap_is_member_of_directorship.clear_cache()
-
-
-def clear_current_students_cache():
-    ldap_get_current_students.cache_clear()

--- a/conditional/blueprints/cache_management.py
+++ b/conditional/blueprints/cache_management.py
@@ -71,4 +71,4 @@ def clear_committee_cache():
 
 
 def clear_current_students_cache():
-    ldap.get_current_students.cache_clear()
+    ldap_get_current_students.cache_clear()

--- a/conditional/util/ldap.py
+++ b/conditional/util/ldap.py
@@ -1,6 +1,8 @@
 from functools import lru_cache
 
 from conditional import ldap
+from conditional.blueprints.cache_management import clear_current_students_cache
+from conditional.blueprints.cache_management import clear_members_cache
 
 
 def _ldap_get_group_members(group):
@@ -97,18 +99,22 @@ def ldap_is_current_student(account):
 
 def ldap_set_housingpoints(account, housing_points):
     account.housingPoints = housing_points
+    clear_current_students_cache()
 
 
 def ldap_set_roomnumber(account, room_number):
     account.roomNumber = room_number
+    clear_current_students_cache()
 
 
 def ldap_set_active(account):
     _ldap_add_member_to_group(account, 'active')
+    clear_members_cache()
 
 
 def ldap_set_inactive(account):
     _ldap_remove_member_from_group(account, 'active')
+    clear_members_cache()
 
 
 def ldap_get_roomnumber(account):

--- a/conditional/util/ldap.py
+++ b/conditional/util/ldap.py
@@ -1,8 +1,7 @@
 from functools import lru_cache
 
 from conditional import ldap
-from conditional.blueprints.cache_management import clear_current_students_cache
-from conditional.blueprints.cache_management import clear_members_cache
+import conditional.blueprints.cache_management
 
 
 def _ldap_get_group_members(group):
@@ -99,22 +98,22 @@ def ldap_is_current_student(account):
 
 def ldap_set_housingpoints(account, housing_points):
     account.housingPoints = housing_points
-    clear_current_students_cache()
+    cache_management.clear_current_students_cache()
 
 
 def ldap_set_roomnumber(account, room_number):
     account.roomNumber = room_number
-    clear_current_students_cache()
+    cache_management.clear_current_students_cache()
 
 
 def ldap_set_active(account):
     _ldap_add_member_to_group(account, 'active')
-    clear_members_cache()
+    cache_management.clear_members_cache()
 
 
 def ldap_set_inactive(account):
     _ldap_remove_member_from_group(account, 'active')
-    clear_members_cache()
+    cache_management.clear_members_cache()
 
 
 def ldap_get_roomnumber(account):


### PR DESCRIPTION
…e changed.

Some notes generally about our caching strategy..

`lru_cache` is a process-wide memory cache, I am not sure how conditional is deployed but if we are using some gunicorn, uwsgi, mod_wsgi etc. that uses multiple threads then our cache isn't going to invalidate properly as a clear cache call doesn't extend across all threads. Therefore some users will get the clear cache and expected behavior and others won't. To fix this we would need to install a standalone cache like memcached or redis.

We also aren't capturing every change to ldap, we are invalidating cache when a value is changed by conditional, but if someone is modifying ldap by any other means we aren't receiving those signals that something changed and the cache is invalid. The solution here would be some form of webhook on the ldap server that calls the `clear_cache` route when it is modified meeting x, y, z conditions.


side note: I might be a dingus, am I supposed to commit to the develop branch to create a comprehensive PR that bumps us to the next version?  