### PR TITLE
removed initial attendance submission warning

### DIFF
--- a/frontend/javascript/modules/attendanceForm.js
+++ b/frontend/javascript/modules/attendanceForm.js
@@ -52,9 +52,7 @@ export default class AttendanceForm {
           }
         });
 
-        FetchUtil.postWithWarning(this.endpoint, payload, {
-          warningText: "You will not be able to edit this event once " +
-                        "attendance has been recorded.",
+        FetchUtil.post(this.endpoint, payload, {
           successText: "Attendance has been submitted."
         });
       });


### PR DESCRIPTION
Now that attendance can be modified, there should not be a warning that attendance cannot be changed.