### PR TITLE
Add placeholder text for the major project form

### DIFF
--- a/conditional/templates/major_project_submission.html
+++ b/conditional/templates/major_project_submission.html
@@ -11,7 +11,8 @@ Major Project Form
             <div class="panel-body">
                 <div class="form-group label-floating is-empty">
                     <label class="control-label" for="name">Project Name</label>
-                    <input class="form-control" id="name" name="name" type="text" maxlength="64">
+                    <input class="form-control" id="name" name="name" type="text" maxlength="64"
+                     placeholder="A clever name for your project, sometimes people will come up with an acronym.">
                 </div>
             </div>
         </div>
@@ -19,7 +20,8 @@ Major Project Form
             <div class="panel-body" style="padding-top:20px;">
                 <div class="form-group label-floating is-empty">
                     <label class="control-label" for="description">Description</label>
-                    <textarea name="description" class="form-control" rows="3" id="description"></textarea>
+                    <textarea name="description" class="form-control" rows="3" id="description"
+                     placeholder="A 'two liner' description of what your project is. If you have source materials like a GitHub repo publicly available, it's also useful to include links to them."></textarea>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This will be useful to guide members for writing better descriptions of their
projects and listing out things like GitHub repos associated with the project.


The text is currently up for debate, but regardless of what it says in the end I think we should be implementing something like this.