### PR TITLE
Don't Remove Eval Director from Active Group

### DIFF
--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -627,8 +627,9 @@ def clear_active_members():
 
     # Clear the active group.
     for account in members:
-        log.info('Remove {} from Active Status'.format(account.uid))
-        ldap_set_inactive(account)
+        if account.uid != username:
+            log.info('Remove {} from Active Status'.format(account.uid))
+            ldap_set_inactive(account)
     return jsonify({"success": True}), 200
 
 


### PR DESCRIPTION
We can't have empty groups and the ED should always be active during the transition.