### PR TITLE
Major Project History on Dashboard

### DIFF
--- a/conditional/blueprints/dashboard.py
+++ b/conditional/blueprints/dashboard.py
@@ -89,8 +89,7 @@ def display_dashboard():
             'status': p.status,
             'description': p.description
         } for p in
-        MajorProject.query.filter(MajorProject.uid == member.uid,
-                                  MajorProject.date > start_of_year())]
+        MajorProject.query.filter(MajorProject.uid == member.uid)]
 
     data['major_projects_count'] = len(data['major_projects'])
 


### PR DESCRIPTION
Change the Major Projects panel on the dashboard to show all of the
major projects ever submitted by a member.

@mbillow optionally we could also display the date here (but I personally don't think that's of vital importance).