### PR TITLE
Fix HM Attendance on Intro Evals Page

### DIFF
--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -113,7 +113,7 @@ def display_intro_evals(internal=False):
         elif freshman_data.freshman_eval_result != "Pending" and internal:
             continue
 
-        h_meetings = [m.meeting_id for m in get_hm(member)]
+        h_meetings = [m.meeting_id for m in get_hm(member, only_absent=True)]
         member_info = {
             'name': name,
             'uid': uid,


### PR DESCRIPTION
When a member has a house meeting absence excused it should not count
against them.