### PR TITLE
Fix 'ritDn' parser for active member export button

### DIFF
--- a/conditional/blueprints/member_management.py
+++ b/conditional/blueprints/member_management.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import re
 
 from datetime import datetime
 
@@ -626,7 +625,8 @@ def export_active_list():
     active_list = [["Full Name", "RIT Username", "Amount to Charge"]]
     for member in ldap_get_active_members():
         full_name = member.cn
-        rit_username = re.search(".*uid=(\\w*)", member.ritDn).group(1)
+        # XXX[ljm] this should be renamed in LDAP/IPA schema to be ritUid
+        rit_username = member.ritDn
         will_coop = CurrentCoops.query.filter(
             CurrentCoops.date_created > start_of_year(),
             CurrentCoops.uid == member.uid).first()


### PR DESCRIPTION
As of 2018-09-01 the ritDn field in LDAP contains data in the following
format:
    ABC1234
Rather than the older (and incorrect in terms of DNs) format:
    uid=ABC1234,ou=people,dc=rit,dc=edu

This fixes an issue where accounts created under the new FreeIPA
infrastructure would populate the ritDn field with the uid of the member
in respect to their RIT account, but not in a full dn format.


Since this change is trivial, looking for review from either Marc or Devin (or anyone).