### PR TITLE
Create route for getting co-op list

### DIFF
--- a/conditional/blueprints/co_op.py
+++ b/conditional/blueprints/co_op.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import structlog
 from flask import Blueprint, request, jsonify
 
@@ -49,6 +51,25 @@ def submit_co_op_form(user_dict=None):
     db.session.commit()
 
     return jsonify({"success": True}), 200
+
+
+@co_op_bp.route('/co_op/list', methods=['GET'])
+def get_co_op_list(user_dict=None):
+    # TODO: Authenticate properly
+    log = logger.new(request=request, auth_dict=user_dict)
+    log.info('Get list of students currently on Co-Op')
+
+    if datetime.today() < datetime(start_of_year().year, 12, 31):
+        semester = 'Fall'
+    else:
+        semester = 'Spring'
+
+    co_op_list = [{member.uid}
+                  for member in CurrentCoops.query.filter(
+            CurrentCoops.date_created > start_of_year(),
+            CurrentCoops.semester == semester).all()]
+
+    return jsonify(co_op_list)
 
 
 @co_op_bp.route('/co_op/<uid>', methods=['DELETE'])


### PR DESCRIPTION
For packet, we need a list of who is currently on co-op

This route provides that list to be able to generate a packet season for all active members, excluding those on co-op.

Issue:
Authentication is hard when it's not a user using the route, instead of the packet cli.
I'm personally not concerned about exposing this route, but I understand the concern and looking to find a good way to do it.