### PR TITLE
Fixing multi-line names from clipping content in presentations

### DIFF
--- a/conditional/templates/intro_eval_slideshow.html
+++ b/conditional/templates/intro_eval_slideshow.html
@@ -13,7 +13,7 @@ Introductory Evaluations Slideshow
     <section id="slide-{{m['uid']}}">
       <section>
         <img class="eval-user-img" alt="{{m['uid']}}" src="https://profiles.csh.rit.edu/image/{{m['uid']}}" />
-        <h1>{{m['name']}}</h1>
+        <h1 class="member-name">{{m['name']}}</h1>
           <div class="row">
             <div class="col-xs-12 col-md-3">
               {% set packet_passed = m['signatures_missed'] == 0 %}

--- a/conditional/templates/spring_eval_slideshow.html
+++ b/conditional/templates/spring_eval_slideshow.html
@@ -13,7 +13,7 @@ Membership Evaluations Slideshow
     <section id="slide-{{m['uid']}}">
       <section>
         <img class="eval-user-img" alt="{{m['uid']}}" src="https://profiles.csh.rit.edu/image/{{m['uid']}}" />
-        <h1>{{m['name']}}</h1>
+        <h1 class="member-name">{{m['name']}}</h1>
         <div class="row">
           <div class="col-xs-12 col-md-4">
             {% set committee_meetings_passed = m['committee_meetings'] >= m['req_meetings'] %}

--- a/frontend/javascript/modules/presentation.js
+++ b/frontend/javascript/modules/presentation.js
@@ -12,6 +12,15 @@ export default class Presentation {
   }
   render() {
     reveal.initialize();
+
+    const name = $('h1.member-name');
+    const nameHeight = name.height();
+    const nameLineheight = parseFloat(name.css('line-height'));
+    const nameRows = nameHeight / nameLineheight; // get # lines of name elem
+    if (nameRows > 1) { // if name wraps to two lines
+      name.css('font-size', '1.5em');
+    }
+
     $('.reveal button.pass').click(e => {
       let uid = e.target.parentElement.dataset.uid; // Ex: ID of 'pass-ram' => 'ram'
       let cn = e.target.parentElement.dataset.cn;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5818258/47825058-55b25580-dd46-11e8-80bc-e9674505ce3a.png)
Fixes error in screenshot above where names that are too long clip the pass/fail buttons on the intro/spring evaluations slideshows.