### PR TITLE
Make the number of active members visible

### DIFF
--- a/conditional/templates/dashboard.html
+++ b/conditional/templates/dashboard.html
@@ -195,7 +195,6 @@ Dashboard
             {% endif %}
 
 
-            {% if is_eboard %}
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h3 class="panel-title">Member Statistics</h3>
@@ -220,7 +219,6 @@ Dashboard
                     </div>
                 </div>
             </div>
-            {% endif %}
 
 
             {% if major_projects_count == 0 and not active%}


### PR DESCRIPTION
I don't think this should be hidden.
It being hidden makes doing constitution things harder and there's no reason for it to be hidden.