### PR TITLE
Change 10 to 6 for Freshman Directorships

### DIFF
--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -65,7 +65,7 @@ def display_intro_evals(internal=False, user_dict=None):
             'eval_date': fid.eval_date.strftime("%Y-%m-%d"),
             'signatures_missed': signatures_missed,
             'committee_meetings': get_fid_cm_count(fid.id),
-            'committee_meetings_passed': get_fid_cm_count(fid.id) >= 10,
+            'committee_meetings_passed': get_fid_cm_count(fid.id) >= 6,
             'house_meetings_missed':
                 [
                     {
@@ -114,7 +114,7 @@ def display_intro_evals(internal=False, user_dict=None):
             'eval_date': freshman_data.eval_date.strftime("%Y-%m-%d"),
             'signatures_missed': freshman_data.signatures_missed,
             'committee_meetings': len(get_cm(member)),
-            'committee_meetings_passed': len(get_cm(member)) >= 10,
+            'committee_meetings_passed': len(get_cm(member)) >= 6,
             'house_meetings_missed':
                 [
                     {

--- a/conditional/models/models.py
+++ b/conditional/models/models.py
@@ -21,7 +21,7 @@ class FreshmanAccount(db.Model):
     def __init__(self, name, onfloor, room=None, missed=None, rit_username=None):
         self.name = name
         today = date.fromtimestamp(time.time())
-        self.eval_date = today + timedelta(weeks=10)
+        self.eval_date = today + timedelta(weeks=6)
         self.onfloor_status = onfloor
         self.room_number = room
         self.signatures_missed = missed

--- a/conditional/templates/dashboard.html
+++ b/conditional/templates/dashboard.html
@@ -61,9 +61,9 @@ Dashboard
                         <tr>
                             <td class="title">Directorship Meetings</td>
                             <td><span class="pull-right">
-                                {% if freshman['committee_meetings'] >= 10 %}
+                                {% if freshman['committee_meetings'] >= 6 %}
                                 <span class="glyphicon glyphicon-ok-sign green"></span> {% else %}
-                                <span class="glyphicon glyphicon-remove-sign red"></span> {% endif %} {{freshman['committee_meetings']}} / 10
+                                <span class="glyphicon glyphicon-remove-sign red"></span> {% endif %} {{freshman['committee_meetings']}} / 6
                                 </span>
                             </td>
                         </tr>

--- a/conditional/templates/intro_eval_slideshow.html
+++ b/conditional/templates/intro_eval_slideshow.html
@@ -24,7 +24,7 @@ Introductory Evaluations Slideshow
               </div>
             </div>
             <div class="col-xs-12 col-md-3">
-              {% set committee_meetings_passed = m['committee_meetings'] >= 10 %}
+              {% set committee_meetings_passed = m['committee_meetings'] >= 6 %}
               <div class="item{% if committee_meetings_passed %} passed{% endif %}" >
                 <span class="icon glyphicon glyphicon-{% if committee_meetings_passed %}ok passed{%else%}remove{% endif %}" aria-hidden="true"></span>
                 <h3>{{m['committee_meetings']}}</h3>

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -74,15 +74,15 @@ Introductory Evaluations
                                 {% endif %}
                             </div>
                             <div class="text-center">
-                                {% if m['committee_meetings'] < 10 %}
+                                {% if m['committee_meetings'] < 6 %}
                                     <div class="eval-info-label">
                                         <span class="glyphicon glyphicon-remove-sign red eval-info-status"></span>Directorship Meetings
-                                        <span class="eval-info-number">{{m['committee_meetings']}} / 10</span>
+                                        <span class="eval-info-number">{{m['committee_meetings']}} / 6</span>
                                     </div>
                                     {% else %}
                                     <div class="eval-info-label">
                                         <span class="glyphicon glyphicon-ok-sign green eval-info-status"></span>Directorship Meetings
-                                        <span class="eval-info-number">{{m['committee_meetings']}} / 10</span>
+                                        <span class="eval-info-number">{{m['committee_meetings']}} / 6</span>
                                     </div>
                                 {% endif %}
 
@@ -204,7 +204,7 @@ Introductory Evaluations
                             {% endif %}
                         </td>
                         <td data-sort="{{ m['committee_meetings'] }}">
-                            {% if m['committee_meetings'] < 10 %}
+                            {% if m['committee_meetings'] < 6 %}
                                 <span class="glyphicon glyphicon-remove-sign red eval-info-status"></span> {{m['committee_meetings']}}
                             {% else %}
                                 <span class="glyphicon glyphicon-ok-sign green eval-info-status"></span> {{m['committee_meetings']}}


### PR DESCRIPTION
For Freshman Evals, Conditional still showed a requirement of 10
directorships isntead of the new 6. This fixes that for the visual "/6"
and the check for a check or X mark.


@Lontronix 