### PR TITLE
Add Committee Meetings to Intro Evals Page Pt. 2

### DIFF
--- a/conditional/blueprints/intro_evals.py
+++ b/conditional/blueprints/intro_evals.py
@@ -32,10 +32,24 @@ def display_intro_evals(internal=False, user_dict=None):
     log.info('Display Intro Evals Listing')
 
     # get user data
-    def get_fid_cm_count(member_id):
-        return len([a for a in FreshmanCommitteeAttendance.query.filter(
-            FreshmanCommitteeAttendance.fid == member_id)
-            if CommitteeMeeting.query.filter(CommitteeMeeting.id == a.meeting_id).first().approved])
+    def get_fid_cm(member):
+        c_meetings = [{
+            "uid": cm[0],
+            "timestamp": cm[1],
+            "committee": cm[2]
+        } for cm in CommitteeMeeting.query.join(
+            FreshmanCommitteeAttendance,
+            FreshmanCommitteeAttendance.meeting_id == CommitteeMeeting.id
+            ).with_entities(
+                FreshmanCommitteeAttendance.fid,
+                CommitteeMeeting.timestamp,
+                CommitteeMeeting.committee
+                ).filter(
+                    CommitteeMeeting.timestamp > start_of_year(),
+                    FreshmanCommitteeAttendance.fid == member,
+                    CommitteeMeeting.approved == True # pylint: disable=singleton-comparison
+                    ).all()]
+        return c_meetings
 
     members = ldap_get_intro_members()
 
@@ -64,8 +78,12 @@ def display_intro_evals(internal=False, user_dict=None):
             'uid': fid.id,
             'eval_date': fid.eval_date.strftime("%Y-%m-%d"),
             'signatures_missed': signatures_missed,
-            'committee_meetings': get_fid_cm_count(fid.id),
-            'committee_meetings_passed': get_fid_cm_count(fid.id) >= 6,
+            'committee_meetings': [{
+                "uid": cm['uid'],
+                "timestamp": cm['timestamp'].strftime("%Y-%m-%d"),
+                "committee": cm['committee']
+            } for cm in get_fid_cm(fid.id)],
+            'committee_meetings_passed': len(get_fid_cm(fid.id)) >= 6,
             'house_meetings_missed':
                 [
                     {
@@ -113,7 +131,11 @@ def display_intro_evals(internal=False, user_dict=None):
             'uid': uid,
             'eval_date': freshman_data.eval_date.strftime("%Y-%m-%d"),
             'signatures_missed': freshman_data.signatures_missed,
-            'committee_meetings': len(get_cm(member)),
+            'committee_meetings': [{
+                "uid": cm['uid'],
+                "timestamp": cm['timestamp'].strftime("%Y-%m-%d"),
+                "committee": cm['committee']
+            } for cm in get_cm(member)],
             'committee_meetings_passed': len(get_cm(member)) >= 6,
             'house_meetings_missed':
                 [
@@ -147,7 +169,7 @@ def display_intro_evals(internal=False, user_dict=None):
         ie_members.append(member_info)
 
     ie_members.sort(key=lambda x: len(x['house_meetings_missed']))
-    ie_members.sort(key=lambda x: x['committee_meetings'], reverse=True)
+    ie_members.sort(key=lambda x: x['committee_meetings_passed'], reverse=True)
     ie_members.sort(key=lambda x: x['signatures_missed'])
     ie_members.sort(key=lambda x: x['status'] == "Passed")
 

--- a/conditional/templates/intro_evals.html
+++ b/conditional/templates/intro_evals.html
@@ -74,15 +74,15 @@ Introductory Evaluations
                                 {% endif %}
                             </div>
                             <div class="text-center">
-                                {% if m['committee_meetings'] < 6 %}
+                                {% if m['committee_meetings']|length < 6 %}
                                     <div class="eval-info-label">
                                         <span class="glyphicon glyphicon-remove-sign red eval-info-status"></span>Directorship Meetings
-                                        <span class="eval-info-number">{{m['committee_meetings']}} / 6</span>
+                                        <span class="eval-info-number">{{m['committee_meetings']|length}} / 6</span>
                                     </div>
                                     {% else %}
                                     <div class="eval-info-label">
                                         <span class="glyphicon glyphicon-ok-sign green eval-info-status"></span>Directorship Meetings
-                                        <span class="eval-info-number">{{m['committee_meetings']}} / 6</span>
+                                        <span class="eval-info-number">{{m['committee_meetings']|length}} / 6</span>
                                     </div>
                                 {% endif %}
 
@@ -136,8 +136,27 @@ Introductory Evaluations
                 </table>
                 {% endif %}
                 <!-- ^^ HOUSE MEETINGS TABLE -->
-                {% if m['technical_seminars']|length > 0 %}
+                {% if m['committee_meetings']|length > 0 %}
+                <h4>Directorship Meetings</h4>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Directorship</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for meeting in m['committee_meetings'] %}
+                        <tr>
+                            <td>{{meeting['timestamp']}}</td>
+                            <td>{{meeting['committee']}}</td>
+                        </tr>
+                        {% endfor %}
 
+                    </tbody>
+                </table>
+                {% endif %}
+                {% if m['technical_seminars']|length > 0 %}
                 <h4>Technical Seminars</h4>
                 <table class="table">
                     <tbody>
@@ -203,11 +222,11 @@ Introductory Evaluations
                             <span class="glyphicon glyphicon-remove red"></span> Failed
                             {% endif %}
                         </td>
-                        <td data-sort="{{ m['committee_meetings'] }}">
-                            {% if m['committee_meetings'] < 6 %}
-                                <span class="glyphicon glyphicon-remove-sign red eval-info-status"></span> {{m['committee_meetings']}}
+                        <td data-sort="{{ m['committee_meetings']|length }}">
+                            {% if m['committee_meetings']|length < 6 %}
+                                <span class="glyphicon glyphicon-remove-sign red eval-info-status"></span> {{m['committee_meetings']|length}}
                             {% else %}
-                                <span class="glyphicon glyphicon-ok-sign green eval-info-status"></span> {{m['committee_meetings']}}
+                                <span class="glyphicon glyphicon-ok-sign green eval-info-status"></span> {{m['committee_meetings']|length}}
                             {% endif %}
                         </td>
                         <td data-sort="{{ m['signatures_missed'] }}">


### PR DESCRIPTION
Would keep all information an evals director would want on the intro evals page. Everything else for an intro member's requirements are shown in the table view except for their committee meetings.

Unfucked the old PR, this time featuring screenshots!

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/40615740/160264059-5695722e-6671-46af-8349-6e555dcd445b.png">

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/40615740/160264065-412d0874-a645-4162-9756-4443bf3c3144.png">
