### PR TITLE
Prevent people from pinging @channel

### DIFF
--- a/conditional/blueprints/major_project_submission.py
+++ b/conditional/blueprints/major_project_submission.py
@@ -69,6 +69,10 @@ def submit_major_project(user_dict=None):
         return jsonify({"success": False}), 400
     project = MajorProject(user_dict['username'], name, description)
 
+    # Don't you dare try pinging @channel
+    if "@" in name:
+        name = "@ ".join(name.split("@"))
+
     username = user_dict['username']
     send_slack_ping({"text":f"<!subteam^S5XENJJAH> *{get_member_name(username)}* ({username})"
                             f" submitted their major project, *{name}*!"})


### PR DESCRIPTION
You're welcome Joe.

A few days ago, this happened:
![image](https://github.com/ComputerScienceHouse/conditional/assets/55056986/d4114f52-901f-4927-96ee-0daa76b99896)

This change inserts spaces after any @ signs in major project submissions. This should prevent such a ping from happening again. 