### PR TITLE
fix profiles icon

### DIFF
--- a/conditional/templates/nav_protected.html
+++ b/conditional/templates/nav_protected.html
@@ -94,7 +94,7 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="/dashboard"><i class="bi bi-display"></i> Dashboard</a></li>
-                        <li><a href="https://profiles.csh.rit.edu/user/{{username}}"><i class="bi bi-person-full"></i> Profiles</a></li>
+                        <li><a href="https://profiles.csh.rit.edu/user/{{username}}"><i class="bi bi-person-fill"></i> Profiles</a></li>
                         <li role="separator" class="divider"></li>
                         <li><a href="https://members.csh.rit.edu/"><i class="bi bi-display"></i> Members Portal</a></li>
                         <li><a href="https://github.com/ComputerScienceHouse/conditional/issues"><i class="bi bi-exclamation-circle"></i> Report an Issue</a></li>


### PR DESCRIPTION
## What

Fix profiles icon on protected pages (dashboard)

Old: 
<img width="161" height="57" alt="image" src="https://github.com/user-attachments/assets/908fd71e-1453-4023-9826-61b6d35ccc42" />

New:
<img width="140" height="52" alt="image" src="https://github.com/user-attachments/assets/dc5cec4d-b027-4f0c-ad07-c455e4125116" />


## Why

It was broken

## Test Plan

go to dashboard and see it works 

## Env Vars

nope :)

## Checklist

- [x] Tested all changes locally
