### PR TITLE
add _director to evals and financial in the auth dict

### DIFF
--- a/conditional/util/auth.py
+++ b/conditional/util/auth.py
@@ -22,8 +22,8 @@ def webauth_request(func):
                      "is_active": is_active,
                      "is_alumni": is_alumni,
                      "is_eboard": is_eboard,
-                     "is_financial": is_financial,
-                     "is_eval": is_eval}, *args, **kwargs)
+                     "is_financial_director": is_financial,
+                     "is_eval_director": is_eval}, *args, **kwargs)
 
     return wrapped_func
 


### PR DESCRIPTION
## What

Adds _director to the is_evals_director and is_financial_director in the auth dict used when accessing pages.

## Why

Templates expect _director, this was not in auth dict.

## Test Plan

ran it

## Env Vars

no

## Checklist

- [ :heavy_check_mark: ] Tested all changes locally
