### PR TITLE
Fixed E-Board director role checking

### DIFF
--- a/conditional/util/auth.py
+++ b/conditional/util/auth.py
@@ -1,32 +1,8 @@
 from functools import wraps
 
-from flask import request, session
+from flask import session
 
-from conditional.util.ldap import ldap_is_active, ldap_is_alumni, \
-    ldap_is_eboard, ldap_is_eval_director, \
-    ldap_is_financial_director, ldap_get_member, ldap_is_current_student
-
-
-def webauth_request(func):
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        user_name = request.headers.get('x-webauth-user')
-        account = ldap_get_member(user_name)
-        is_active = ldap_is_active(account)
-        is_alumni = ldap_is_alumni(account)
-        is_eboard = ldap_is_eboard(account)
-        is_financial = ldap_is_financial_director(account)
-        is_eval = ldap_is_eval_director(account)
-
-        return func({"user_name": user_name,
-                     "is_active": is_active,
-                     "is_alumni": is_alumni,
-                     "is_eboard": is_eboard,
-                     "is_financial_director": is_financial,
-                     "is_eval_director": is_eval}, *args, **kwargs)
-
-    return wrapped_func
-
+from conditional.util.ldap import ldap_get_member, ldap_is_current_student
 
 def get_user(func):
     @wraps(func)

--- a/conditional/util/ldap.py
+++ b/conditional/util/ldap.py
@@ -22,9 +22,8 @@ def _ldap_remove_member_from_group(account: CSHMember, group: str):
 
 
 @service_cache(maxsize=256)
-def _ldap_is_member_of_directorship(account: CSHMember, directorship: str):
-    return account.in_group(f'eboard-{directorship}', dn=True)
-# TODO: try in_group(ldap.get_group(f'eboard-{directorship}')) and profile
+def _ldap_is_member_of_directorship(member: CSHMember, directorship: str):
+    return _ldap_is_member_of_group(member, f'eboard-{directorship}')
 
 @service_cache(maxsize=1024)
 def ldap_get_member(username: str) -> CSHMember:
@@ -81,7 +80,7 @@ def ldap_is_eboard(account) -> bool:
 
 @service_cache(maxsize=128)
 def ldap_is_rtp(account) -> bool:
-    return _ldap_is_member_of_group(account, 'rtp')
+    return _ldap_is_member_of_group(account, 'active_rtp')
 
 
 @service_cache(maxsize=128)
@@ -96,12 +95,12 @@ def ldap_is_onfloor(account) -> bool:
 
 @service_cache(maxsize=128)
 def ldap_is_financial_director(account) -> bool:
-    return _ldap_is_member_of_directorship(account, 'Financial')
+    return _ldap_is_member_of_directorship(account, 'financial')
 
 
 @service_cache(maxsize=128)
 def ldap_is_eval_director(account) -> bool:
-    return _ldap_is_member_of_directorship(account, 'Evaluations')
+    return _ldap_is_member_of_directorship(account, 'evaluations')
 
 
 @service_cache(maxsize=256)


### PR DESCRIPTION
## What

The function to check if you were a certain E-Board member was not working. This fixes it. This also removes an unused legacy function.

## Why

E-Board members weren't getting the proper access to Conditional.

## Test Plan

ran locally tested with users.

## Env Vars

no

## Checklist

- [✔️ ] Tested all changes locally
