### PR TITLE
moved gunicorn config out of dockerfile args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ COPY --from=build-frontend /opt/conditional/conditional/static /opt/conditional/
 
 RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
-CMD ["sh", "-c", "gunicorn conditional:app"]
+CMD ["sh", "-c", "gunicorn"]
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,6 +1,7 @@
 import os
 
-bind = f'0.0.0.0:{os.getenv('PORT')}'
+wsgi_app = 'conditional:app'
+bind = f'0.0.0.0:{os.getenv('PORT', 8080)}'
 workers = os.getenv('CONDITIONAL_WORKERS', 1)
 accesslog = '-'
 timeout = 256


### PR DESCRIPTION
## What

Moves the gunicorn config out of dockerfile so you can just run it with `gunicorn`

## Why

Having it all in the dockerfile was cumbersome and maybe I'm thinking about a better way to do datadog in our flask apps and this makes it so much easier

## Test Plan

Ran dockerfile with updated arguements as well as just `gunicorn` in a venv

## Env Vars

Yes, added (well renamed) `WEB_CONCURRENCY` to `CONDITIONAL_WORKERS`

## Checklist

- [x] Tested all changes locally
