### PR TITLE
Fixed redirect_uri

### DIFF
--- a/config.env.py
+++ b/config.env.py
@@ -42,9 +42,10 @@ OIDC_ISSUER = env.get("CONDITIONAL_OIDC_ISSUER", "https://sso.csh.rit.edu/auth/r
 OIDC_CLIENT_CONFIG = {
     'client_id': env.get("CONDITIONAL_OIDC_CLIENT_ID", "conditional"),
     'client_secret': env.get("CONDITIONAL_OIDC_CLIENT_SECRET", ""),
-    'redirect_uri': env.get("CONDITIONAL_OIDC_REDIRECT_URI", "http://localhost:8080/redirect_uri"),
     'post_logout_redirect_uris': [env.get("CONDITIONAL_OIDC_CLIENT_LOGOUT", "http://0.0.0.0:8080/logout")],
 }
+
+OIDC_REDIRECT_URI = env.get("CONDITIONAL_OIDC_REDIRECT_URI", "http://localhost:8080/redirect_uri")
 
 # Openshift secret
 SECRET_KEY = env.get("CONDITIONAL_SECRET_KEY", default=''.join(secrets.token_hex(16)))


### PR DESCRIPTION
## What

Moved the redirect uri from the `OIDC_CLIENT_CONFIG` dict to its own variable

## Why

Fix issue (idk exactly but noah said this was needed)

## Test Plan

Uhhh test it locally with creds i think? Not entirely sure tbh

## Env Vars

Removed `redirect_uri` from `OIDC_CLIENT_CONFIG`, and made it a separate variable named `OIDC_REDIRECT_URI` instead

## Checklist

- [X] Tested all changes locally
