### PR TITLE
make dockerfile use uv and separate dependency stages 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM node:25-bookworm-slim AS build-frontend
+FROM node:25-trixie-slim AS build-frontend
 
 RUN mkdir /opt/conditional 
 
 WORKDIR /opt/conditional
-
-RUN apt-get -yq update && \
-    apt-get -yq install curl git 
 
 COPY package.json package-lock.json /opt/conditional/
 
@@ -16,7 +13,7 @@ COPY frontend /opt/conditional/frontend
 
 RUN npm run webpack 
 
-FROM astral/uv:python3.12-bookworm-slim
+FROM astral/uv:python3.13-trixie-slim
 MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 
 WORKDIR /opt/conditional

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY frontend /opt/conditional/frontend
 
 RUN npm run webpack
 
-FROM docker.io/python:3.12-slim-bookworm
+FROM astral/uv:python3.12-bookworm-slim
 MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 
 WORKDIR /opt/conditional
@@ -24,9 +24,9 @@ WORKDIR /opt/conditional
 COPY requirements.txt /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install libsasl2-dev libldap2-dev libldap-common libssl-dev gcc g++ make && \
-    pip install -r requirements.txt && \
-    apt-get -yq clean all
+    apt-get -yq install libsasl2-dev libldap2-dev libldap-common libssl-dev gcc g++ make
+RUN uv pip install --system -r requirements.txt
+RUN apt-get -yq clean all
 
 ARG PORT=8080
 ENV PORT=${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 WORKDIR /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install libldap2-dev libldap-common libsasl2-dev libssl-dev gcc g++ make  && \
+    apt-get -yq install gcc g++ libldap2-dev libldap-common libsasl2-dev libssl-dev make  && \
     apt-get -yq clean all 
 
 COPY requirements.txt /opt/conditional

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 WORKDIR /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install gcc g++ libldap2-dev libldap-common libsasl2-dev libssl-dev make  && \
+    apt-get -yq install g++ gcc libldap-common libldap2-dev libsasl2-dev libssl-dev make && \
     apt-get -yq clean all 
 
 COPY requirements.txt /opt/conditional

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 WORKDIR /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install libsasl2-dev libldap2-dev libldap-common libssl-dev gcc g++ make 
+    apt-get -yq install libldap2-dev libldap-common libsasl2-dev libssl-dev gcc g++ make  && \
+    apt-get -yq clean all 
 
 COPY requirements.txt /opt/conditional
 
-RUN uv pip install --system -r requirements.txt && \
-    apt-get -yq clean all 
+RUN uv pip install --system -r requirements.txt 
 
 ARG PORT=8080
 ENV PORT=${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY frontend /opt/conditional/frontend
 RUN npm run webpack 
 
 FROM astral/uv:python3.13-trixie-slim
-MAINTAINER Computer Science House <webmaster@csh.rit.edu>
+LABEL maintainer="Computer Science House <webmaster@csh.rit.edu>"
 
 WORKDIR /opt/conditional
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 WORKDIR /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install g++ gcc libldap-common libldap2-dev libsasl2-dev libssl-dev make && \
+    apt-get -yq --no-install-recommends install g++ gcc libldap-common libldap2-dev libsasl2-dev libssl-dev make && \
     apt-get -yq clean all 
 
 COPY requirements.txt /opt/conditional

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:25-bookworm-slim AS build-frontend
 
-RUN mkdir /opt/conditional
+RUN mkdir /opt/conditional 
 
 WORKDIR /opt/conditional
 
 RUN apt-get -yq update && \
-    apt-get -yq install curl git
+    apt-get -yq install curl git 
 
 COPY package.json package-lock.json /opt/conditional/
 
@@ -14,19 +14,20 @@ RUN npm ci
 COPY webpack.config.js /opt/conditional
 COPY frontend /opt/conditional/frontend
 
-RUN npm run webpack
+RUN npm run webpack 
 
 FROM astral/uv:python3.12-bookworm-slim
 MAINTAINER Computer Science House <webmaster@csh.rit.edu>
 
 WORKDIR /opt/conditional
 
+RUN apt-get -yq update && \
+    apt-get -yq install libsasl2-dev libldap2-dev libldap-common libssl-dev gcc g++ make 
+
 COPY requirements.txt /opt/conditional
 
-RUN apt-get -yq update && \
-    apt-get -yq install libsasl2-dev libldap2-dev libldap-common libssl-dev gcc g++ make
-RUN uv pip install --system -r requirements.txt
-RUN apt-get -yq clean all
+RUN uv pip install --system -r requirements.txt && \
+    apt-get -yq clean all 
 
 ARG PORT=8080
 ENV PORT=${PORT}


### PR DESCRIPTION
## What

make dockerfile use uv and separate dependency stages 

## Why

Builds locally are really slow and you have to reinstall everything when you update a python dependencies
This makes it so it doesn't have to install all system packages to make better use of caching

## Test Plan

Ran it

## Env Vars

Nope

## Documentation

Nope

## Checklist

- [x] Tested all changes locally
