### PR TITLE
Check if user is spring intro member so it returns the right number of directorships

### DIFF
--- a/conditional/util/member.py
+++ b/conditional/util/member.py
@@ -146,7 +146,8 @@ def get_hm(member, only_absent=False):
 # @service_cache(maxsize=128) # Can't hash because members_on_coop is a list
 def req_cm(uid, members_on_coop=None):
     # Get the number of required committee meetings based on if the member
-    # is going on co-op in the current operating session.
+    # is going on co-op in the current operating session, or if the member
+    # was a spring intro member.
     on_coop = False
 
     if members_on_coop:
@@ -157,7 +158,16 @@ def req_cm(uid, members_on_coop=None):
             CurrentCoops.date_created > start_of_year()).first()
         if co_op:
             on_coop = True
-    if on_coop:
+            
+    spring_semester_start = datetime(start_of_year().year + 1, 1, 1)
+    
+    is_spring_intro = FreshmanEvalData.query.filter(
+        FreshmanEvalData.uid == uid,
+        FreshmanEvalData.freshman_eval_result == "Passed",
+        FreshmanEvalData.eval_date >= spring_semester_start
+    ).first() is not None
+    
+    if on_coop or is_spring_intro:
         return 15
     return 30
 

--- a/conditional/util/member.py
+++ b/conditional/util/member.py
@@ -158,15 +158,15 @@ def req_cm(uid, members_on_coop=None):
             CurrentCoops.date_created > start_of_year()).first()
         if co_op:
             on_coop = True
-            
+
     spring_semester_start = datetime(start_of_year().year + 1, 1, 1)
-    
+
     is_spring_intro = FreshmanEvalData.query.filter(
         FreshmanEvalData.uid == uid,
         FreshmanEvalData.freshman_eval_result == "Passed",
         FreshmanEvalData.eval_date >= spring_semester_start
     ).first() is not None
-    
+
     if on_coop or is_spring_intro:
         return 15
     return 30


### PR DESCRIPTION
## What

Updates the req_cm function in member.py to check if a user was a spring intro member, and returns 15 (directorships) if they were a spring intro member.

## Why

Spring intro members only need 15 directorships to pass spring evals but currently in Conditional it requires 30 for all members because it didn't check if they were a spring intro member.

## Test Plan

I added an existing active member to the freshman_eval_data in my local database + set the eval_date to this year's spring intro evals date to make sure that the required number of directorships is set to 15 for spring intro members who passed intro evals.

## Env Vars

No

## Documentation

I changed the comment at the start of req_cm to reflect that it now gets the number of required directorships based on if the member is on co_op or is a spring intro member who passed intro evals.

## Checklist

- [x] Tested all changes locally
