### PR TITLE
Increase maxlength for skill input from 16 to 64

### DIFF
--- a/conditional/templates/major_project_submission.html
+++ b/conditional/templates/major_project_submission.html
@@ -81,7 +81,7 @@ Major Project Form
                                 id="skill-input"
                                 name="skill"
                                 type="text"
-                                maxlength="16"
+                                maxlength="64"
                                 placeholder="Add a skill"
                                 class="form-control border-0 w-100"
                                 required


### PR DESCRIPTION
## What

Increase maxlength for skill input from 16 to 64

## Why

Skills with names longer than 16 characters couldn't be entered. 30 characters seems reasonable.

## Test Plan

run locally. ez pz frontend update

## Env Vars

N/A

## Documentation

N/A

## Checklist

- [x] Tested all changes locally
