### PR TITLE
fix: resubmit project with same name no longer corrupts skill linkage

### DIFF
--- a/conditional/blueprints/major_project_submission.py
+++ b/conditional/blueprints/major_project_submission.py
@@ -122,10 +122,7 @@ def submit_major_project(user_dict=None):
     db.session.add(project)
     db.session.commit()
 
-    project = MajorProject.query.filter(
-        MajorProject.name == name,
-        MajorProject.uid == user_id
-    ).first()
+    project = MajorProject.query.get(project.id)
 
     skills_list: list = list(filter(lambda x: x != 'None', skills))
 


### PR DESCRIPTION
## Problem

Resubmitting a major project with the same name as a previous submission fails with an integrity error. The skills get linked to the wrong project.

## Root Cause

The re-query at `conditional/blueprints/major_project_submission.py:125-128` filters by `(name, uid)`, which returns any matching project — not necessarily the one just created. When skills are then inserted using the wrong project ID, the composite PK `(project_id, skill)` collides with already-existing skills.

## Fix

Query by the known primary key (`project.id`) instead of `(name, uid)`. After `db.session.commit()`, SQLAlchemy has populated `project.id` with the auto-generated value.

## Test

Created an isolated testbench using SQLAlchemy with the exact production model definitions:

| Scenario | Result |
|----------|--------|
| Initial submission | ✅ Skills linked correctly |
| Resubmit same name+skills (buggy) | ❌ Re-query returns old project ID, PK collision |
| Resubmit same name+skills (fixed) | ✅ Each project gets its own skills |
| 3 submissions, all same name+skills | ✅ All 3 projects have all 3 skills |

Fixes #586