### PR TITLE
fix: check roomNumber key before indexing

### DIFF
--- a/conditional/util/housing.py
+++ b/conditional/util/housing.py
@@ -24,12 +24,17 @@ def get_housing_queue(is_eval_director=False):
     }
 
     queue = ldap.get_group_member_attributes(groups=['current_student'],
-                                             excluded_groups=[], attributes=['uid', 'housingPoints', 'cn'])
+                                             excluded_groups=[],
+                                             attributes=['uid', 'housingPoints', 'cn', 'roomNumber'])
 
-    # if the user is not evals, they should only see people in the cue without a room number
+    # if the user is not evals, they should only see people in the queue without a room number
     if not is_eval_director:
-        queue = list(filter(lambda member: member['uid'] in in_queue and member['roomNumber'] is not None, queue))
-
+        def member_in_queue(member):
+            return (
+               member['uid'] in in_queue
+               and ('roomNumber' not in member or member['roomNumber'] is not None)
+            )
+        queue = list(filter(member_in_queue, queue))
 
     # set the time they were added to the queue
     # i'm sorry this is cursed, it's this way because of database structure or something


### PR DESCRIPTION
## What

- title

## Why

- explodes otherwise
```
File "/opt/conditional/conditional/util/housing.py", line 47, in get_queue_position
queue = get_housing_queue()
File "/opt/conditional/conditional/util/housing.py", line 31, in get_housing_queue
queue = list(filter(lambda member: member['uid'] in in_queue and member['roomNumber'] is not None, queue))
File "/opt/conditional/conditional/util/housing.py", line 31, in <lambda>
queue = list(filter(lambda member: member['uid'] in in_queue and member['roomNumber'] is not None, queue))
~~~~~~^^^^^^^^^^^^^^
KeyError: 'roomNumber'
```

## Test Plan

- check it doesn't explode
  - probably needs to be checked by an off floor member

## Env Vars

- nah

## Documentation

- nah

## Checklist

- [x] Tested all changes locally
